### PR TITLE
Removal of SkiaSharp.Views and SkiaSharp.Views.WPF

### DIFF
--- a/DynamicWin/DynamicWin.csproj
+++ b/DynamicWin/DynamicWin.csproj
@@ -33,8 +33,6 @@
     <PackageReference Include="NAudio.Wasapi" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SkiaSharp" Version="2.88.8" />
-    <PackageReference Include="SkiaSharp.Views" Version="2.88.8" />
-    <PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.8" />
     <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
 

--- a/DynamicWin/Main/RendererMain.cs
+++ b/DynamicWin/Main/RendererMain.cs
@@ -11,11 +11,8 @@ using DynamicWin.UI.Menu;
 using DynamicWin.UI.Menu.Menus;
 using DynamicWin.UI.UIElements;
 using DynamicWin.Utils;
-using OpenTK.Graphics;
-using OpenTK;
+using DynamicWin.WPFBinders;
 using SkiaSharp;
-using SkiaSharp.Views.Desktop;
-using SkiaSharp.Views.WPF;
 
 namespace DynamicWin.Main
 {

--- a/DynamicWin/UI/UIElements/Custom/TrayFile.cs
+++ b/DynamicWin/UI/UIElements/Custom/TrayFile.cs
@@ -1,7 +1,6 @@
 ﻿using DynamicWin.Main;
 using DynamicWin.Utils;
 using SkiaSharp;
-using SkiaSharp.Views.Desktop;
 using System;
 using System.Collections.Generic;
 using System.Drawing;

--- a/DynamicWin/UI/UIElements/DWImage.cs
+++ b/DynamicWin/UI/UIElements/DWImage.cs
@@ -1,7 +1,6 @@
 ﻿using DynamicWin.Resources;
 using DynamicWin.Utils;
 using SkiaSharp;
-using SkiaSharp.Views.Desktop;
 using System;
 using System.Collections.Generic;
 using System.Drawing;

--- a/DynamicWin/UI/Widgets/Big/ShortcutsWidget.cs
+++ b/DynamicWin/UI/Widgets/Big/ShortcutsWidget.cs
@@ -6,7 +6,6 @@ using DynamicWin.UI.UIElements.Custom;
 using DynamicWin.Utils;
 using Newtonsoft.Json;
 using SkiaSharp;
-using SkiaSharp.Views.Desktop;
 using System;
 using System.Collections.Generic;
 using System.Configuration;

--- a/DynamicWin/Utils/BitmapExtensions.cs
+++ b/DynamicWin/Utils/BitmapExtensions.cs
@@ -1,0 +1,65 @@
+﻿using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media.Imaging;
+using System.Windows;
+using System.Drawing.Imaging;
+
+namespace DynamicWin.Utils
+{
+    public static class BitmapExtensions
+    {
+        public static SKBitmap ToSKBitmap(this Bitmap bitmap)
+        {
+            var info = new SKImageInfo(bitmap.Width, bitmap.Height);
+            var skiaBitmap = new SKBitmap(info);
+            using (var pixmap = skiaBitmap.PeekPixels())
+            {
+                bitmap.ToSKPixmap(pixmap);
+            }
+            return skiaBitmap;
+        }
+
+        public static SKImage ToSKImage(this Bitmap bitmap)
+        {
+            var info = new SKImageInfo(bitmap.Width, bitmap.Height);
+            var image = SKImage.Create(info);
+            using (var pixmap = image.PeekPixels())
+            {
+                bitmap.ToSKPixmap(pixmap);
+            }
+            return image;
+        }
+
+        public static void ToSKPixmap(this Bitmap bitmap, SKPixmap pixmap)
+        {
+            if (pixmap.ColorType == SKImageInfo.PlatformColorType)
+            {
+                var info = pixmap.Info;
+                using (var tempBitmap = new Bitmap(info.Width, info.Height, info.RowBytes, PixelFormat.Format32bppPArgb, pixmap.GetPixels()))
+                using (var gr = Graphics.FromImage(tempBitmap))
+                {
+                    // Clear graphic to prevent display artifacts with transparent bitmaps
+                    gr.Clear(Color.Transparent);
+
+                    gr.DrawImageUnscaled(bitmap, 0, 0);
+                }
+            }
+            else
+            {
+                // we have to copy the pixels into a format that we understand
+                // and then into a desired format
+                // we can still do a bit more for other cases where the color types are the same
+                using (var tempImage = bitmap.ToSKImage())
+                {
+                    tempImage.ReadPixels(pixmap, 0, 0);
+                }
+            }
+        }
+
+    }
+}

--- a/DynamicWin/WPFBinders/SKElement.cs
+++ b/DynamicWin/WPFBinders/SKElement.cs
@@ -1,0 +1,129 @@
+﻿using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media.Imaging;
+using System.Windows.Media;
+using System.Windows;
+
+namespace DynamicWin.WPFBinders
+{
+    [DefaultEvent("PaintSurface")]
+    [DefaultProperty("Name")]
+    public class SKElement : FrameworkElement
+    {
+        private const double BitmapDpi = 96.0;
+
+        private readonly bool designMode;
+
+        private WriteableBitmap bitmap;
+        private bool ignorePixelScaling;
+
+        public SKElement()
+        {
+            designMode = DesignerProperties.GetIsInDesignMode(this);
+        }
+
+        public SKSize CanvasSize { get; private set; }
+
+        public bool IgnorePixelScaling
+        {
+            get => ignorePixelScaling;
+            set
+            {
+                ignorePixelScaling = value;
+                InvalidateVisual();
+            }
+        }
+
+        [Category("Appearance")]
+        public event EventHandler<SKPaintSurfaceEventArgs> PaintSurface;
+
+        protected override void OnRender(DrawingContext drawingContext)
+        {
+            base.OnRender(drawingContext);
+
+            if (designMode)
+                return;
+
+            if (Visibility != Visibility.Visible || PresentationSource.FromVisual(this) == null)
+                return;
+
+            var size = CreateSize(out var unscaledSize, out var scaleX, out var scaleY);
+            var userVisibleSize = IgnorePixelScaling ? unscaledSize : size;
+
+            CanvasSize = userVisibleSize;
+
+            if (size.Width <= 0 || size.Height <= 0)
+                return;
+
+            var info = new SKImageInfo(size.Width, size.Height, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
+
+            // reset the bitmap if the size has changed
+            if (bitmap == null || info.Width != bitmap.PixelWidth || info.Height != bitmap.PixelHeight)
+            {
+                bitmap = new WriteableBitmap(info.Width, size.Height, BitmapDpi * scaleX, BitmapDpi * scaleY, PixelFormats.Pbgra32, null);
+            }
+
+            // draw on the bitmap
+            bitmap.Lock();
+            using (var surface = SKSurface.Create(info, bitmap.BackBuffer, bitmap.BackBufferStride))
+            {
+                if (IgnorePixelScaling)
+                {
+                    var canvas = surface.Canvas;
+                    canvas.Scale(scaleX, scaleY);
+                    canvas.Save();
+                }
+
+                OnPaintSurface(new SKPaintSurfaceEventArgs(surface, info.WithSize(userVisibleSize), info));
+            }
+
+            // draw the bitmap to the screen
+            bitmap.AddDirtyRect(new Int32Rect(0, 0, info.Width, size.Height));
+            bitmap.Unlock();
+            drawingContext.DrawImage(bitmap, new Rect(0, 0, ActualWidth, ActualHeight));
+        }
+
+        protected virtual void OnPaintSurface(SKPaintSurfaceEventArgs e)
+        {
+            // invoke the event
+            PaintSurface?.Invoke(this, e);
+        }
+
+        protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
+        {
+            base.OnRenderSizeChanged(sizeInfo);
+
+            InvalidateVisual();
+        }
+
+        private SKSizeI CreateSize(out SKSizeI unscaledSize, out float scaleX, out float scaleY)
+        {
+            unscaledSize = SKSizeI.Empty;
+            scaleX = 1.0f;
+            scaleY = 1.0f;
+
+            var w = ActualWidth;
+            var h = ActualHeight;
+
+            if (!IsPositive(w) || !IsPositive(h))
+                return SKSizeI.Empty;
+
+            unscaledSize = new SKSizeI((int)w, (int)h);
+
+            var m = PresentationSource.FromVisual(this).CompositionTarget.TransformToDevice;
+            scaleX = (float)m.M11;
+            scaleY = (float)m.M22;
+            return new SKSizeI((int)(w * scaleX), (int)(h * scaleY));
+
+            bool IsPositive(double value)
+            {
+                return !double.IsNaN(value) && !double.IsInfinity(value) && value > 0;
+            }
+        }
+    }
+}

--- a/DynamicWin/WPFBinders/SKPaintSurfaceEventArgs.cs
+++ b/DynamicWin/WPFBinders/SKPaintSurfaceEventArgs.cs
@@ -1,0 +1,30 @@
+﻿using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DynamicWin.WPFBinders
+{
+    public class SKPaintSurfaceEventArgs : EventArgs
+    {
+        public SKPaintSurfaceEventArgs(SKSurface surface, SKImageInfo info)
+            : this(surface, info, info)
+        {
+        }
+
+        public SKPaintSurfaceEventArgs(SKSurface surface, SKImageInfo info, SKImageInfo rawInfo)
+        {
+            Surface = surface;
+            Info = info;
+            RawInfo = rawInfo;
+        }
+
+        public SKSurface Surface { get; }
+
+        public SKImageInfo Info { get; }
+
+        public SKImageInfo RawInfo { get; }
+    }
+}


### PR DESCRIPTION
The removal of those packages allows to a full net-8.0 compilation (SkiaSharp.Views was being restored with .NetFramework4.6).

The code that were using those packages was the methods using `thumbnail.ToSKBitmap()` that was replaced with the needed source code mentioned in [mono/SkiaSharp#1633](https://github.com/mono/SkiaSharp/issues/1633), and the `RenderMain` class that was inheriting `SKElement`, replaced with the code from the [source repo of SkiaSharp](https://github.com/mono/SkiaSharp/blob/main/source/SkiaSharp.Views/SkiaSharp.Views.WPF/SKElement.cs).

I'm doing this aiming to a full dotnet based compilation (instead of relying to msbuild/Visual Studio) for a future pipeline CI/CD and also allow to be executed in ARM64 windows machines.