### PR TITLE
Minor visual adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vs/
 /DynamicWin/bin/
 /DynamicWin/obj/
+/DynamicWinSetup

--- a/DynamicWin/Main/App.xaml.cs
+++ b/DynamicWin/Main/App.xaml.cs
@@ -16,7 +16,7 @@ namespace DynamicWin
         public static MMDevice defaultDevice;
         public static MMDevice defaultMicrophone;
 
-        public static string Version => "1.0.7r";
+        public static string Version => "1.1.0b";
 
         [STAThread]
         public static void Main()

--- a/DynamicWin/Main/MainForm.xaml.cs
+++ b/DynamicWin/Main/MainForm.xaml.cs
@@ -141,7 +141,7 @@ namespace DynamicWin.Main
             {
                 _lastRenderTime = currentTime;
 
-                onMainFormRender.Invoke();
+                onMainFormRender?.Invoke();
             }
         }
 

--- a/DynamicWin/UI/Menu/Menus/SettingsMenu.cs
+++ b/DynamicWin/UI/Menu/Menus/SettingsMenu.cs
@@ -102,22 +102,22 @@ namespace DynamicWin.UI.Menu.Menus
                 objects.Add(islandMode);
             }
 
-            allowBlur = new Checkbox(island, "Allow Blur", new Vec2(25, 0), new Vec2(25, 25), () => { }, UIAlignment.TopLeft);
+            allowBlur = new Checkbox(island, "Toggle blur", new Vec2(25, 0), new Vec2(25, 25), () => { }, UIAlignment.TopLeft);
             allowBlur.IsChecked = Settings.AllowBlur;
             allowBlur.Anchor.X = 0;
             objects.Add(allowBlur);
 
-            allowAnimation = new Checkbox(island, "Allow SO Animation", new Vec2(25, 0), new Vec2(25, 25), () => { }, UIAlignment.TopLeft);
+            allowAnimation = new Checkbox(island, "Toggle animations", new Vec2(25, 0), new Vec2(25, 25), () => { }, UIAlignment.TopLeft);
             allowAnimation.IsChecked = Settings.AllowAnimation;
             allowAnimation.Anchor.X = 0;
             objects.Add(allowAnimation);
 
-            antiAliasing = new Checkbox(island, "Anti Aliasing", new Vec2(25, 0), new Vec2(25, 25), () => { }, UIAlignment.TopLeft);
+            antiAliasing = new Checkbox(island, "Toggle anti-aliasing", new Vec2(25, 0), new Vec2(25, 25), () => { }, UIAlignment.TopLeft);
             antiAliasing.IsChecked = Settings.AntiAliasing;
             antiAliasing.Anchor.X = 0;
             objects.Add(antiAliasing);
 
-            runOnStartup = new Checkbox(island, "Run App on System Startup", new Vec2(25, 0), new Vec2(25, 25), () => { }, UIAlignment.TopLeft);
+            runOnStartup = new Checkbox(island, "Start application on login", new Vec2(25, 0), new Vec2(25, 25), () => { }, UIAlignment.TopLeft);
             runOnStartup.IsChecked = Settings.RunOnStartup;
             runOnStartup.Anchor.X = 0;
             objects.Add(runOnStartup);
@@ -126,7 +126,6 @@ namespace DynamicWin.UI.Menu.Menus
             {
                 var selectedMonitorTitle = new DWText(island, "Selected Monitor", new Vec2(25, 0), UIAlignment.TopLeft);
                 selectedMonitorTitle.Font = Res.InterRegular;
-                selectedMonitorTitle.Color = Theme.TextSecond;
                 selectedMonitorTitle.TextSize = 15;
                 selectedMonitorTitle.Anchor.X = 0;
                 objects.Add(selectedMonitorTitle);
@@ -175,7 +174,7 @@ namespace DynamicWin.UI.Menu.Menus
             objects.Add(widgetsTitle);
 
             {
-                var wTitle = new DWText(island, "Small Widgets (right click to add/edit)", new Vec2(25, 0), UIAlignment.TopLeft);
+                var wTitle = new DWText(island, "Small widgets (right click to add/edit)", new Vec2(25, 0), UIAlignment.TopLeft);
                 wTitle.Font = Res.InterRegular;
                 wTitle.Color = Theme.TextSecond;
                 wTitle.TextSize = 15;
@@ -194,7 +193,7 @@ namespace DynamicWin.UI.Menu.Menus
             });
 
             {
-                var wTitle = new DWText(island, "Big Widgets (right click to add/edit)", new Vec2(25, 15), UIAlignment.TopLeft);
+                var wTitle = new DWText(island, "Big widgets (right click to add/edit)", new Vec2(25, 15), UIAlignment.TopLeft);
                 wTitle.Font = Res.InterRegular;
                 wTitle.Color = Theme.TextSecond;
                 wTitle.TextSize = 15;
@@ -223,7 +222,6 @@ namespace DynamicWin.UI.Menu.Menus
                 {
                     var wTitle = new DWText(island, option.SettingTitle, new Vec2(25, 0), UIAlignment.TopLeft);
                     wTitle.Font = Res.InterRegular;
-                    wTitle.Color = Theme.TextSecond;
                     wTitle.TextSize = 15;
                     wTitle.Anchor.X = 0;
                     objects.Add(wTitle);
@@ -253,7 +251,7 @@ namespace DynamicWin.UI.Menu.Menus
                 }
             }
 
-            objects.Add(new DWText(island, "Software Version: " + DynamicWinMain.Version, new Vec2(25, 0), UIAlignment.TopLeft)
+            objects.Add(new DWText(island, "Software version: " + DynamicWinMain.Version, new Vec2(25, 0), UIAlignment.TopLeft)
             {
                 Color = Theme.TextThird,
                 Anchor = new Vec2(0, 0.5f),
@@ -267,29 +265,31 @@ namespace DynamicWin.UI.Menu.Menus
                 TextSize = 15
             });
 
-            objects.Add(new DWText(island, "Maintained and developed by Megan Park! (59xa)", new Vec2(25, -20), UIAlignment.TopLeft)
+            objects.Add(new DWText(island, "Maintained and developed by 59xa", new Vec2(25, 0), UIAlignment.TopLeft)
             {
                 Color = Theme.TextThird,
-                Anchor = new Vec2(0, 0f),
-                TextSize = 12
+                Anchor = new Vec2(0, 0.5f),
+                TextSize = 12,
+                Font = Resources.Res.InterBold
             });
 
-            objects.Add(new DWText(island, "Licensed under the CC BY-SA 4.0 licence.", new Vec2(25, -15), UIAlignment.TopLeft)
+            objects.Add(new DWText(island, "Licenced under the CC BY-SA 4.0 licence.", new Vec2(25, 0), UIAlignment.TopLeft)
             {
                 Color = Theme.TextThird,
-                Anchor = new Vec2(0, 0f),
+                Anchor = new Vec2(0, 0.5f),
                 TextSize = 15
             });
 
-            var backBtn = new DWTextButton(island, "Apply and Back", new Vec2(0, -45), new Vec2(350, 40), () => { SaveAndBack(); }, UIAlignment.BottomCenter)
+            var backBtn = new DWTextButton(island, "Save changes", new Vec2(0, -45), new Vec2(250, 40), () => { SaveAndBack(); }, UIAlignment.BottomCenter)
             {
                 roundRadius = 25
             };
             backBtn.Text.Font = Resources.Res.InterBold;
 
-            bottomMask = new UIObject(island, Vec2.zero, new Vec2(IslandSizeBig().X + 100, 200), UIAlignment.BottomCenter)
+            bottomMask = new UIObject(island, Vec2.zero, new Vec2(IslandSizeBig().X - 225, 175), UIAlignment.BottomCenter)
             {
-                Color = Theme.IslandBackground
+                Color = Theme.IslandBackground,
+                roundRadius = 50
             };
 
             objects.Add(bottomMask);
@@ -531,7 +531,7 @@ namespace DynamicWin.UI.Menu.Menus
                 var ctx2 = new ContextMenu();
                 ctx2.Items.Add(new MenuItem()
                 {
-                    Header = "No Widgets Available.",
+                    Header = "No widgets available.",
                     IsEnabled = false
                 });
                 return ctx2;

--- a/DynamicWin/UI/Menu/Menus/SettingsMenu.cs
+++ b/DynamicWin/UI/Menu/Menus/SettingsMenu.cs
@@ -175,7 +175,7 @@ namespace DynamicWin.UI.Menu.Menus
             objects.Add(widgetsTitle);
 
             {
-                var wTitle = new DWText(island, "Small Widgets (Right click to add / edit)", new Vec2(25, 0), UIAlignment.TopLeft);
+                var wTitle = new DWText(island, "Small Widgets (right click to add/edit)", new Vec2(25, 0), UIAlignment.TopLeft);
                 wTitle.Font = Res.InterRegular;
                 wTitle.Color = Theme.TextSecond;
                 wTitle.TextSize = 15;
@@ -194,7 +194,7 @@ namespace DynamicWin.UI.Menu.Menus
             });
 
             {
-                var wTitle = new DWText(island, "Big Widgets (Right click to add / edit)", new Vec2(25, 15), UIAlignment.TopLeft);
+                var wTitle = new DWText(island, "Big Widgets (right click to add/edit)", new Vec2(25, 15), UIAlignment.TopLeft);
                 wTitle.Font = Res.InterRegular;
                 wTitle.Color = Theme.TextSecond;
                 wTitle.TextSize = 15;
@@ -267,10 +267,17 @@ namespace DynamicWin.UI.Menu.Menus
                 TextSize = 15
             });
 
-            objects.Add(new DWText(island, "Licensed under the MIT license.", new Vec2(25, 0), UIAlignment.TopLeft)
+            objects.Add(new DWText(island, "Maintained and developed by Megan Park! (59xa)", new Vec2(25, -20), UIAlignment.TopLeft)
             {
                 Color = Theme.TextThird,
-                Anchor = new Vec2(0, 0.5f),
+                Anchor = new Vec2(0, 0f),
+                TextSize = 12
+            });
+
+            objects.Add(new DWText(island, "Licensed under the CC BY-SA 4.0 licence.", new Vec2(25, -15), UIAlignment.TopLeft)
+            {
+                Color = Theme.TextThird,
+                Anchor = new Vec2(0, 0f),
                 TextSize = 15
             });
 

--- a/DynamicWin/UI/Menu/Menus/SettingsMenu.cs
+++ b/DynamicWin/UI/Menu/Menus/SettingsMenu.cs
@@ -19,6 +19,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Navigation;
 using System.Xml.Linq;
+using static DynamicWin.UI.UIElements.IslandObject;
 using static System.Net.Mime.MediaTypeNames;
 
 namespace DynamicWin.UI.Menu.Menus
@@ -391,9 +392,12 @@ namespace DynamicWin.UI.Menu.Menus
             return customOptions;
         }
 
+        // Border should only be rendered if on island mode instead of notch
         public override Col IslandBorderColor()
         {
-            return new Col(0.5f, 0.5f, 0.5f);
+            IslandMode mode = Settings.IslandMode; // Reads either Island or Notch as value
+            if (mode == IslandMode.Island) return new Col(0.5f, 0.5f, 0.5f);
+            else return new Col(0, 0, 0, 0); // Render transparent if island mode is Notch
         }
     }
 

--- a/DynamicWin/UI/UIElements/IslandObject.cs
+++ b/DynamicWin/UI/UIElements/IslandObject.cs
@@ -114,8 +114,8 @@ namespace DynamicWin.UI.UIElements
             {
                 var path = new SKPath();
 
-                var awidth = (float)(Math.Max(15f, Size.Y / 9));
-                var aheight = (float)(Math.Max(Size.Y / 4, 15)) + (LocalPosition.Y - topOffset);
+                var awidth = (float)(Math.Max(0f, Size.Y / 45));
+                var aheight = (float)(Math.Max(Size.Y / 45, 15)) + (LocalPosition.Y - topOffset);
                 var y = 0;
 
                 { // Left notch curve

--- a/DynamicWin/UI/UIObject.cs
+++ b/DynamicWin/UI/UIObject.cs
@@ -29,7 +29,9 @@ namespace DynamicWin.UI
         public Vec2 Position { get => GetPosition() + localPosition; set => position = value; }
         public Vec2 LocalPosition { get => localPosition; set => localPosition = value; }
         public Vec2 Anchor { get => anchor; set => anchor = value; }
-        public Vec2 Size { get => size; set => size = value; }
+
+        // TODO: look further into this null pointer issue
+        public Vec2 Size { get => size ?? Vec2.one; set => size = value; } // Temporary fix for null size especially with BottomLeft getter
         public Col Color { get => new Col(color.r, color.g, color.b, color.a * Alpha); set => color = value; }
 
         private bool isHovering = false;

--- a/DynamicWin/UI/Widgets/Big/WeatherWidget.cs
+++ b/DynamicWin/UI/Widgets/Big/WeatherWidget.cs
@@ -62,7 +62,7 @@ namespace DynamicWin.UI.Widgets.Big
         {
             var objects = new List<UIObject>();
 
-            var hideLocationCheckbox = new Checkbox(null, "Hide Location", new Vec2(25, 0), new Vec2(25, 25), null, alignment: UIAlignment.TopLeft);
+            var hideLocationCheckbox = new Checkbox(null, "Hide current location", new Vec2(25, 0), new Vec2(25, 25), null, alignment: UIAlignment.TopLeft);
             hideLocationCheckbox.IsChecked = saveData.hideLocation;
 
             hideLocationCheckbox.clickCallback += () =>
@@ -72,7 +72,7 @@ namespace DynamicWin.UI.Widgets.Big
 
             objects.Add(hideLocationCheckbox);
 
-            var useCelciusCheckbox = new Checkbox(null, "Use Celcius", new Vec2(25, 0), new Vec2(25, 25), null, alignment: UIAlignment.TopLeft);
+            var useCelciusCheckbox = new Checkbox(null, "Use Celsius as temperature measurement", new Vec2(25, 0), new Vec2(25, 25), null, alignment: UIAlignment.TopLeft);
             useCelciusCheckbox.IsChecked = saveData.useCelcius;
 
             useCelciusCheckbox.clickCallback += () =>

--- a/DynamicWin/UI/Widgets/Small/SmallVisualizerWidget.cs
+++ b/DynamicWin/UI/Widgets/Small/SmallVisualizerWidget.cs
@@ -10,7 +10,7 @@ namespace DynamicWin.UI.Widgets.Small
     class RegisterSmallVisualizerWidget : IRegisterableWidget
     {
         public bool IsSmallWidget => true;
-        public string WidgetName => "Audio Visualizer";
+        public string WidgetName => "Audio Visualiser";
 
         public WidgetBase CreateWidgetInstance(UIObject? parent, Vec2 position, UIAlignment alignment = UIAlignment.TopCenter)
         {

--- a/DynamicWin/UI/Widgets/Small/TimeWidget.cs
+++ b/DynamicWin/UI/Widgets/Small/TimeWidget.cs
@@ -60,7 +60,7 @@ namespace DynamicWin.UI.Widgets.Small
         {
             var objects = new List<UIObject>();
 
-            var militaryTime = new Checkbox(null, "24 Hour Clock", new Vec2(25, 0), new Vec2(25, 25), null, UIAlignment.TopLeft);
+            var militaryTime = new Checkbox(null, "24-Hour Time", new Vec2(25, 0), new Vec2(25, 25), null, UIAlignment.TopLeft);
 
             militaryTime.clickCallback += () =>
             {

--- a/DynamicWin/UI/Widgets/Small/UsedDevicesWidget.cs
+++ b/DynamicWin/UI/Widgets/Small/UsedDevicesWidget.cs
@@ -69,7 +69,7 @@ namespace DynamicWin.UI.Widgets.Small
                 saveData.indicatorThreshold = x;
             };
 
-            var enableIndicatorCheckbox = new Checkbox(null, "Show Microphone Indicator", new Vec2(25, 0), new Vec2(25, 25), null, alignment: UIAlignment.TopLeft);
+            var enableIndicatorCheckbox = new Checkbox(null, "Display microphone indicator", new Vec2(25, 0), new Vec2(25, 25), null, alignment: UIAlignment.TopLeft);
             enableIndicatorCheckbox.IsChecked = saveData.enableIndicator;
 
             var thresholdText = new DWText(null, "Threshold", new Vec2(25, 0), UIAlignment.TopLeft);

--- a/DynamicWin/Utils/PopupOptions.cs
+++ b/DynamicWin/Utils/PopupOptions.cs
@@ -14,7 +14,7 @@ namespace DynamicWin.Utils
     {
         public string SettingID => "popup_options";
 
-        public string SettingTitle => "Popup Options";
+        public string SettingTitle => "Pop-up Options";
 
         public static PopupOptionsSave saveData;
 
@@ -45,7 +45,7 @@ namespace DynamicWin.Utils
         {
             var objects = new List<UIObject>();
 
-            var volume = new Checkbox(null, "Show Volume Popup", new Vec2(25, 0), new Vec2(25, 25), null, UIAlignment.TopLeft);
+            var volume = new Checkbox(null, "Display volume pop-up", new Vec2(25, 0), new Vec2(25, 25), null, UIAlignment.TopLeft);
 
             volume.clickCallback += () =>
             {
@@ -56,7 +56,7 @@ namespace DynamicWin.Utils
             volume.Anchor.X = 0;
             objects.Add(volume);
 
-            var brightness = new Checkbox(null, "Show Brightness Popup", new Vec2(25, 0), new Vec2(25, 25), null, UIAlignment.TopLeft);
+            var brightness = new Checkbox(null, "Display brightness pop-up", new Vec2(25, 0), new Vec2(25, 25), null, UIAlignment.TopLeft);
 
             brightness.clickCallback += () =>
             {

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 <p align="center">
   <img src="https://img.shields.io/badge/c%23-%23239120.svg?style=for-the-badge&logo=csharp&logoColor=white">
   <a href="https://creativecommons.org/licenses/by-sa/4.0/"><img src="https://img.shields.io/static/v1?label=License&message=CC+BY-SA+4.0&color=%23c49b04&style=for-the-badge"></a>
-  <a href="https://www.youtube.com/@flofdev"><img src="https://img.shields.io/badge/YouTube-%23FF0000.svg?style=for-the-badge&logo=YouTube&logoColor=white"></a>
   <a href="https://discord.gg/UHFuqB9NqR"><img src="https://dcbadge.limes.pink/api/server/https://discord.gg/UHFuqB9NqR)](https://discord.gg/UHFuqB9NqR"></a>
 </p>
 
@@ -14,53 +13,43 @@
 <p xmlns:cc="http://creativecommons.org/ns#" xmlns:dct="http://purl.org/dc/terms/"><a property="dct:title" rel="cc:attributionURL" href="https://github.com/FlorianButz/DynamicWin">DynamicWin</a> by <a rel="cc:attributionURL dct:creator" property="cc:attributionName" href="https://github.com/FlorianButz">Florian Butz</a> is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC BY-SA 4.0<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1" alt=""><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1" alt=""><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg?ref=chooser-v1" alt=""></a></p>
 
 > [!NOTE]
-> I currently do not plan on updating this project any further. Feel free to fork the project, but there won't be any new features from my side.
+> This is a fork of DynamicWin from FlorianButz, while the main repository is discontinued for the time being, expect updates and features within this repository instead.
 
 ### What is it?
 A [Dynamic Island](https://support.apple.com/de-de/guide/iphone/iph28f50d10d/ios) inspired Windows App that brings in a bunch of features like widgets or a file tray that works like a clipboard.
+Similar to dynamic notches that you can find on macOS like [NotchNook](https://lo.cafe/notchnook), this application brings the concept on Windows devices to life.
 
+### Implementation and build
+This application is developed using C# for the logic, and [SkiaSharp](https://github.com/mono/SkiaSharp) to display the graphical interface.
+To build this project, ensure that you have the latest version of **.NET 8.0** installed on your environment.
+
+To get started:
+```bash
+git pull https://github.com/59xa/DynamicWin.git
+```
+
+### Future plans
+If you want to support the development of this project you can create pull requests and contribute to it.<br>
+Feel free to open up a new issue if you encounter any bugs/flaws.
 <br>
-Please note that I messed up the versioning. It is still in early development and no where near finished. v1.0.1R should be v0.0.1B and so on.
-
-### Why did I make this?
-The idea for this application originally came to me when I saw the dynamic island on iPhone for the first time. After seeing that there are no (good) solutions to a Dynamic Island type application on Windows, I got the idea to make my own.
-I only got the motivation to start on it though, after seeing something similar has been done on macOS already [(NotchNook)](https://lo.cafe/notchnook).
-<br><br>
-I love programming and I had the idea stuck in my mind for quite some time now. <br>
-I originally made the project in [Java](https://www.java.com/de/) (luckily, that changed) but didn't get any progress since Java is less connected to the Operating system than a language like C#. <br>
-I re-made the project in [WinForms](https://de.wikipedia.org/wiki/Windows_Forms) getting way better results and being more motivated and then had to migrate it to  [WPF](https://de.wikipedia.org/wiki/Windows_Presentation_Foundation) because of my stupid mistake of not trying if things would actually work before doing it. (:D)
-
-### How did I make this?
-WPF is a powerful UI framework, however to archive the look and feel of this app I decided on creating every UI element from scratch using [SkiaSharp](https://github.com/mono/SkiaSharp) for the rendering. This allowed me to create an app that looks like something you would find on macOS which was perfect for this project.
-
-### Why am I writing all of this instead of talking about the features?
-I wanted to give you a peak at what went into this project and why/how I made it.
-
-<br>
-If you want to support the development of this project you can create pull requests and contribute to it or make extensions / themes and upload them on the discord :) <br>
-Feel free to open up a new issue if you encounter any bugs / flaws.
-
-<br>
-Quick disclaimer: The code is terribly structured and almost un-maintainable as it was only meant to be a small side project so please don't expect too much from me :)
+**Quick disclaimer**: The codebase is currently structured terribly and almost un-maintainable. A possible re-write of the entire codebase may happen some time in the future.
 
 # Features
 > [!NOTE]
-> Only the checked features are currently available. The unchecked ones are not guaranteed to come, but are on my mind.
+> Only the checked features are currently available. Unimplemented features will be introduced as time passes.
 
 DynamicWin has a variety of features, currently including: <br>
 
 ## Shortcuts
 - [x] `Ctrl + Win` Will hide the island (or show it again).
-- [ ] `Shift + Win` Will open a quick search menu.
+- [ ] ~~`Shift + Win` Will open a quick search menu.~~ <sub>(Please consider using an alternative such as [Powertoys Run](https://learn.microsoft.com/en-us/windows/powertoys/run))</sub>
 
 ## Big Widgets
 - [x] Media Playback Widget
 - [x] Timer Widget
 - [x] Weather Widget
-- [ ] Voicemeeter integration Widget
 - [x] Shortcuts Widget <sub>(Can be configured to open a file, e.g. Shortcut, .EXE or any other filetype.)</sub>
 - [ ] Calendar Widget
-- [ ] Tuya Smart integration <sub>(Will probably be turned in to one widget with the shortcuts)</sub>
 
 ## Small Widgets
 - [x] Time Display
@@ -103,7 +92,7 @@ Mods can contain malicious code that can mess up your system, so always check a 
 </p>
 
 > [!NOTE]
-> The above shown themes were generated by ChatGPT. If you want one of them, join the discord and let me know.
+> Custom themes are not the main priority for this repository, but will remain supported for use. Visit Florian's Discord server to get access to more themes like the ones shown from above.
 
 You can use the built-in dark / light theme. You can also create custom themes that fit your liking by going to the `%appdata%/DynamicWin/Theme.json` file. After editing the colors you need to select the `Custom` theme option in the settings. If you already did that, you will need to go back to the settings and click on it again. Otherwise you would have to restart the app.
 <br>
@@ -113,16 +102,16 @@ This is an example of a color:
 The hex code is structured this way: `#rrggbb`. If you want to change the alpha of the color, it is **always** at the start of the code. `#aarrggbb`.
 
 # Known Issues
-The performance might not be the best. I will try my best to add performance options to the settings menu but cannot guarantee a smooth experience for everyone. <br><br>
+The performance might not be the best, as said by Florian. More optimisations in the codebase will happen as time passes. <br><br>
 
 The app might suddenly disappear and upon trying to reopen it a message box will tell you that only one instance of the app can run at the same time. To fix this, open task manager and find the process "DynamicWin". Kill it and start the app again. <br><br>
 
 Too fast interactions might confuse the animation system and will result in an empty menu. To fix this, usually moving the mouse away from the island and then over it again will fix it.
 
 # Creating an Extension
-To create an extension you need an IDE like [Visual Studio](https://visualstudio.microsoft.com/de/vs/community/).
-- Create a new C# Project of the type "Class Library". The target framework has to be `.NET 8`.
-- You will need to add at least `DynamicWin.dll` and the SkiaSharp DLLs as assembly dependencies to your project. [How to add references to a VS project](https://learn.microsoft.com/en-us/visualstudio/ide/how-to-add-or-remove-references-by-using-the-reference-manager?view=vs-2022)
+To create an extension you need an IDE like [Visual Studio 2022](https://visualstudio.microsoft.com/de/vs/community/).
+- Create a new C# project of the type "Class Library". Ensure that the target framework is `.NET 8.0`.
+- You are required to add `DynamicWin.dll` and SkiaSharp DLLs as assembly dependencies to your project. [More information regarding this through here.](https://learn.microsoft.com/en-us/visualstudio/ide/how-to-add-or-remove-references-by-using-the-reference-manager?view=vs-2022)
 - Create a new C# class file, if it's not already there. Rename the class to something like "MyExtension".
 - All extensions must have a class that implements the `IDynamicWinExtension` interface.<br>
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ git pull https://github.com/59xa/DynamicWin.git
 If you want to support the development of this project you can create pull requests and contribute to it.<br>
 Feel free to open up a new issue if you encounter any bugs/flaws.
 <br>
+
 **Quick disclaimer**: The codebase is currently structured terribly and almost un-maintainable. A possible re-write of the entire codebase may happen some time in the future.
 
 # Features


### PR DESCRIPTION
# This pull request addresses two things:
- Notch curve adjustments
- Border display adjustments in `SettingsMenu` if `Settings.IslandMode = IslandMode.Notch`

## Notch curve adjustments
Left and right notch curves have been adjusted to closely resemble the macOS notch visuals. Previous implementation looks weird to look at and it does not respect its intended visual looks.

#### Before:
![image](https://github.com/user-attachments/assets/fdfd606b-8a00-4537-b445-a18d79ecd608)

#### After:
![image](https://github.com/user-attachments/assets/4cbb7198-9ad3-4c95-89e8-345bb71e7a4b)

**Changes in `IslandObject.cs`**
```cs
var awidth = (float)(Math.Max(0f, Size.Y / 45));
var aheight = (float)(Math.Max(Size.Y / 45, 15)) + (LocalPosition.Y - topOffset);
```

## Border display adjustments in `SettingsMenu.cs`
Border should only be shown on `SettingsMenu.cs` if `Settings.IslandMode == IslandMode.Notch`. This pull request addresses the minor visual change.

#### Before:
![image](https://github.com/user-attachments/assets/9983ba1c-58a0-47d2-84ed-1c0bba09a22b)

#### After:
![image](https://github.com/user-attachments/assets/cf1d1858-8e82-430e-9c42-008620c5f809)

**Changes in `SettingsMenu.cs`**
```cs
// Border should only be rendered if on island mode instead of notch
public override Col IslandBorderColor()
{
    IslandMode mode = Settings.IslandMode; // Reads either Island or Notch as value
    if (mode == IslandMode.Island) return new Col(0.5f, 0.5f, 0.5f);
    else return new Col(0, 0, 0, 0); // Render transparent if island mode is Notch
}
```